### PR TITLE
Events log (user added a track)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ The application offers a set of endpoints as well as a websocket necessary to ke
 
 ## Run in dev with:
 
-`java -jar .\target\soundfoundry-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev`
+`java -jar ./target/soundfoundry-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The application offers a set of endpoints as well as a websocket necessary to ke
 
 ## Requirements.
 
-1. You must have a local instance of mongoDB runing in your local environment.
+1. You must have a local instance of mongoDB runing in your local environment or:
 
+`docker run --name mongo -d -p27017:27017 mongo:3.4`
 
+## Run in dev with:
+
+`java -jar .\target\soundfoundry-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev`

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/tfflabs/soundfoundry/WebSocketConfig.java
+++ b/src/main/java/com/tfflabs/soundfoundry/WebSocketConfig.java
@@ -19,6 +19,7 @@ public class WebSocketConfig extends AbstractWebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/soundfoundry-socket").setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/events").setAllowedOrigins("*").withSockJS();
     }
 
 }

--- a/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
+++ b/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
@@ -2,31 +2,23 @@ package com.tfflabs.soundfoundry.controllers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 import com.tfflabs.soundfoundry.dto.Event;
-import com.tfflabs.soundfoundry.services.RoomService;
 
 @Controller
 public class EventsController {
 
-	@Autowired
-	private RoomService roomService;
-	
 	private Logger log = LoggerFactory.getLogger(EventsController.class);
 	
 	@MessageMapping("/events")
 	@SendTo("/topic/events")
 	public Event processEvent(Event event){
-		log.info("Entering this shit");
-		log.debug("Event: {}", event);
+
 		switch(event.getType()){
 		
 		case ADDTRACK:
-			//Track track = new Track();
-			//roomService.addTrack(null, "");
 			log.debug("Evento recibido: {}", event.toJson());
 			break;
 		default:

--- a/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
+++ b/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
@@ -1,0 +1,36 @@
+package com.tfflabs.soundfoundry.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.tfflabs.soundfoundry.dto.Event;
+import com.tfflabs.soundfoundry.services.RoomService;
+
+@Controller
+public class EventsController {
+
+	@Autowired
+	private RoomService roomService;
+	
+	private Logger log = LoggerFactory.getLogger(EventsController.class);
+	
+	@RequestMapping("/events")
+	@SendTo("/topic/playlist")
+	public void sendEvent(Event event){
+		switch(event.getType()){
+		
+		case ADDTRACK:
+			//Track track = new Track();
+			//roomService.addTrack(null, "");
+			log.debug("Evento recibido: {}", event.toJson());
+			break;
+		default:
+			log.warn("Event of type {} not processed", event.getType());
+			break;
+		}
+	}
+}

--- a/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
+++ b/src/main/java/com/tfflabs/soundfoundry/controllers/EventsController.java
@@ -3,10 +3,9 @@ package com.tfflabs.soundfoundry.controllers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-
 import com.tfflabs.soundfoundry.dto.Event;
 import com.tfflabs.soundfoundry.services.RoomService;
 
@@ -18,9 +17,11 @@ public class EventsController {
 	
 	private Logger log = LoggerFactory.getLogger(EventsController.class);
 	
-	@RequestMapping("/events")
-	@SendTo("/topic/playlist")
-	public void sendEvent(Event event){
+	@MessageMapping("/events")
+	@SendTo("/topic/events")
+	public Event processEvent(Event event){
+		log.info("Entering this shit");
+		log.debug("Event: {}", event);
 		switch(event.getType()){
 		
 		case ADDTRACK:
@@ -32,5 +33,6 @@ public class EventsController {
 			log.warn("Event of type {} not processed", event.getType());
 			break;
 		}
+		return event;
 	}
 }

--- a/src/main/java/com/tfflabs/soundfoundry/dto/Event.java
+++ b/src/main/java/com/tfflabs/soundfoundry/dto/Event.java
@@ -1,0 +1,55 @@
+package com.tfflabs.soundfoundry.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+
+public class Event {
+
+	private String user;
+	private EventType type;
+	public EventType getType() {
+		return type;
+	}
+
+	public void setType(EventType type) {
+		this.type = type;
+	}
+
+	private Map<String, String> context = new HashMap<>();
+	
+	public void setContext(String key, String value){
+		context.put(key, value);
+	}
+	
+	public String getContext(String key){
+		return context.get(key);
+	}
+	
+	public Event fromJson(String json){
+		Event event = new Event();
+		return event;		
+	}
+	public String toJson(){
+		Gson gson = new Gson();
+		return gson.toJson(this);
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	public Map<String, String> getContext() {
+		return context;
+	}
+
+	public void setContext(Map<String, String> context) {
+		this.context = context;
+	}
+	
+}

--- a/src/main/java/com/tfflabs/soundfoundry/dto/Event.java
+++ b/src/main/java/com/tfflabs/soundfoundry/dto/Event.java
@@ -5,27 +5,14 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 
+import lombok.Data;
+
+@Data
 public class Event {
 
 	private String user;
 	private EventType type;
-	public EventType getType() {
-		return type;
-	}
-
-	public void setType(EventType type) {
-		this.type = type;
-	}
-
 	private Map<String, String> context = new HashMap<>();
-	
-	public void setContext(String key, String value){
-		context.put(key, value);
-	}
-	
-	public String getContext(String key){
-		return context.get(key);
-	}
 	
 	public Event fromJson(String json){
 		Event event = new Event();
@@ -36,20 +23,4 @@ public class Event {
 		return gson.toJson(this);
 	}
 
-	public String getUser() {
-		return user;
-	}
-
-	public void setUser(String user) {
-		this.user = user;
-	}
-
-	public Map<String, String> getContext() {
-		return context;
-	}
-
-	public void setContext(Map<String, String> context) {
-		this.context = context;
-	}
-	
 }

--- a/src/main/java/com/tfflabs/soundfoundry/dto/EventType.java
+++ b/src/main/java/com/tfflabs/soundfoundry/dto/EventType.java
@@ -1,0 +1,9 @@
+package com.tfflabs.soundfoundry.dto;
+
+public enum EventType {
+	LOGIN,
+	LOGOUT,
+	UPVOTE,
+	DOWNVOTE,
+	ADDTRACK
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -2,3 +2,4 @@ server.port=1337
 spotify.client_id=b9aa91638d7d4137aae536691ec3b5e4
 spotify.client_secret=54113bd51fad4aa99f15fd26603a0cd6
 sportify.redirect_uri=http://localhost:4200/auth_callback
+logging.level.com.tfflabs=DEBUG

--- a/src/test/java/com/tfflabs/soundfoundry/dto/EventTest.java
+++ b/src/test/java/com/tfflabs/soundfoundry/dto/EventTest.java
@@ -1,0 +1,27 @@
+package com.tfflabs.soundfoundry.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventTest {
+
+	@Test
+	public void itSerializesToJson(){
+		//Given
+		Event event = new Event();
+		event.setUser("amoya");
+		event.setType(EventType.ADDTRACK);
+		Map<String, String> context = new HashMap<>();
+		context.put("title", "Black Hole Sun");
+		context.put("artist", "Soundgarden");
+		event.setContext(context);
+		//When
+		String json = event.toJson();
+		//Then
+		assertEquals("{\"user\":\"amoya\",\"type\":\"ADDTRACK\",\"context\":{\"artist\":\"Soundgarden\",\"title\":\"Black Hole Sun\"}}", json);
+	}
+}


### PR DESCRIPTION
This PR adds a new WS endpoint for events and bounces the addTrackEvent to clients so the FE can show a log of songs added by other people connected.

The events socket may be used in the future for other purposes